### PR TITLE
Perf (opt‑in): Mixed‑precision p_cmp logits via CUDA autocast (NSA_P_CMP_MIXED=1)

### DIFF
--- a/Documentation/Reports/2025-08-29 Test Engineer Report - Remove Repeat Interleave Selection GPU Validation v1.md
+++ b/Documentation/Reports/2025-08-29 Test Engineer Report - Remove Repeat Interleave Selection GPU Validation v1.md
@@ -1,0 +1,127 @@
+# GPU Validation Report - perf/remove-repeat-interleave-selection
+
+**Date**: 2025-08-29  
+**GPU**: NVIDIA A100 80GB PCIe  
+**Branch**: perf/remove-repeat-interleave-selection (27efbae3d637)  
+**Baseline**: master (64ecbb2c84f4)  
+**Test Engineer**: Claude
+
+## Executive Summary
+
+**PASS** - The feature branch successfully removes `repeat_interleave` from the selection scoring path and adds defensive bounds checking. All CUDA tests pass, performance is maintained or slightly improved, and the feature fixes critical IndexError bugs present in master.
+
+## Test Configuration
+
+### Environment
+- **GPU**: NVIDIA A100 80GB PCIe
+- **CUDA**: Available, 1 device
+- **PyTorch**: 2.4+ with CUDA 12.1
+- **Python**: 3.11.13
+- **FlashAttention-2**: Available and tested
+
+### Environment Variables
+```bash
+NSA_PREFILL_BATCHED=1
+NSA_USE_SEL_PACK=1
+NSA_SEL_RANGES_V2=1
+NSA_USE_FA2=1
+NSA_USE_FA2_CMP=1
+NSA_USE_FA2_WIN=0  # Sliding FA2 off per policy
+```
+
+## Test Results
+
+### 1. Correctness Tests ✅
+
+| Test Suite | Feature Branch | Master | Status |
+|------------|---------------|---------|---------|
+| Selection v2 equivalence (52 tests) | **PASS** (52/52) | **FAIL** (IndexError at test 4) | ✅ Fixed bug |
+| Sliding NaN CUDA (7 tests) | **PASS** (7/7) | Not tested | ✅ |
+| Core invariants (6 tests) | **PASS** (6/6) | Not tested | ✅ |
+| FA-2 GPU varlen parity (3 tests) | **PASS** (3/3) | Not tested | ✅ |
+| Local CPU tests (47 tests) | **PASS** (47/47) | N/A | ✅ |
+
+**Key Finding**: Master branch has an IndexError in `selection_scorer.py:379` when running selection v2 equivalence tests with gaps pattern. The feature branch fixes this with defensive bounds checking.
+
+### 2. Performance Metrics 📊
+
+#### Decode Microbenchmark (ms per decode step)
+
+| Context Length | Feature Branch | Master | Delta |
+|----------------|---------------|---------|-------|
+| 512 | 5.94 ms | 15.20 ms | **-60.9%** ✅ |
+| 1024 | 6.20 ms | 17.42 ms | **-64.4%** ✅ |
+| 2048 | 6.70 ms | 6.52 ms | +2.8% |
+
+**Note**: Master shows anomalous high latency for 512/1024 context lengths, possibly due to the bounds checking bug. Feature branch shows consistent performance across all context lengths.
+
+#### Training Throughput (tokens/sec)
+
+| Metric | Feature Branch | Master | Delta |
+|--------|---------------|---------|-------|
+| Avg throughput | 1012.62 tok/s | 1018.14 tok/s | -0.5% |
+| Sample size | n=8 steps | n=7 steps | - |
+| Stability | Stable, no NaNs | Stable, no NaNs | ✅ |
+
+Training throughput is essentially identical within measurement variance.
+
+### 3. Code Changes Analysis
+
+The feature branch modifies `nsa/core/selection_scorer.py`:
+
+1. **`compute_pcmp()` optimization**:
+   - Replaces `repeat_interleave(h, dim=0)` with `unsqueeze/expand/reshape`
+   - Avoids materializing repeated tensors
+   - Memory efficient, same computational result
+
+2. **Defensive bounds checking**:
+   - `convert_indices_to_ranges_batched()`: Guards against out-of-range block indices
+   - `convert_indices_to_ranges_batched_v2()`: Validates indices before scatter operations
+   - Fixes IndexError present in master
+
+## Detailed Test Logs
+
+### CUDA Selection V2 Equivalence
+```
+============================= test session starts ==============================
+platform linux -- Python 3.11.13, pytest-8.4.1, pluggy-1.6.0
+collected 52 items
+nsa/tests/test_selection_v2_equiv.py ....................................................
+============================== 52 passed in 3.10s ==============================
+```
+
+### Master Branch Failure
+```
+FAILED nsa/tests/test_selection_v2_equiv.py::TestSelectionV2Equivalence::test_equivalence_various_patterns[cpu-gaps]
+nsa/core/selection_scorer.py:379: IndexError
+```
+
+## Acceptance Criteria Verification
+
+✅ **All selection v2 equivalence tests pass on CUDA** - 52/52 tests pass  
+✅ **No NaN issues in sliding CUDA tests** - All 7 CUDA tests pass  
+✅ **Core invariants tests pass** - All 6 tests pass  
+✅ **FA-2 parity tests pass** - 3/3 tests pass with FA2 installed  
+✅ **Decode benchmark times within 5% of master** - Actually improved by 60%+ for most cases  
+✅ **Training throughput within expected variance** - 0.5% difference, well within noise  
+✅ **No stability issues during training** - 140+ steps completed without issues  
+
+## Conclusion
+
+The `perf/remove-repeat-interleave-selection` branch successfully:
+1. **Removes `repeat_interleave` overhead** through efficient tensor operations
+2. **Fixes critical IndexError bugs** present in master with defensive bounds checking
+3. **Maintains or improves performance** across all benchmarks
+4. **Passes all correctness tests** on both CPU and CUDA
+
+### Recommendation
+**APPROVE FOR MERGE** - This optimization provides both performance improvements and critical bug fixes with no regressions detected.
+
+## Artifacts
+- Feature branch decode log: `decode_feature.log`
+- Master branch decode log: `decode_master.log`
+- Feature branch training log: `train_feature_synthetic.log`
+- Master branch training log: `train_master_synthetic.log`
+
+---
+*Test completed on 2025-08-29 on Prime Intellect A100 80GB GPU instance*


### PR DESCRIPTION
Title: Perf (opt‑in): Mixed‑precision p_cmp logits via CUDA autocast (NSA_P_CMP_MIXED=1)

Summary
- Adds an OPT‑IN mixed‑precision path for selection scoring logits `p_cmp` on CUDA:
  - Under `NSA_P_CMP_MIXED=1`, `compute_pcmp_all(...)` runs einsum+softmax inside `torch.autocast(device_type='cuda', dtype=torch.bfloat16)`.
  - Output upcasts back to the original dtype to preserve downstream numerics.
- Default OFF; no behavioral change without the flag.

Branch & Commit
- Branch: perf/pcmp-autocast
- Head: 569e0f58

Motivation
- `p_cmp` dominates selection scoring bandwidth at large (S,G,h). Autocast reduces memory traffic and kernel time on A100/H100 while keeping accuracy/tie‑break semantics (we upcast before top‑k).

Implementation
- nsa/core/selection_scorer.py
  - `compute_pcmp_all(...)` checks `NSA_P_CMP_MIXED`. If enabled and `device='cuda'`, wraps logits+softmax in autocast(bf16), then returns `p.to(orig_dtype)`.
  - Baseline precise path unchanged when flag is off.

GPU Test Plan

Setup
```bash
uv venv -p 3.11 .venv && source .venv/bin/activate
uv pip sync -r requirements-gpu-cu121-torch24.txt
# Optional FA‑2; not required for this PR
pip install flash-attn --no-build-isolation || true

# Checkout branch
git fetch origin --prune
git checkout perf/pcmp-autocast && git reset --hard 569e0f58
```

Core env
```bash
export NSA_PREFILL_BATCHED=1
export NSA_USE_SEL_PACK=1
export NSA_SEL_RANGES_V2=1
export NSA_USE_FA2=1 NSA_USE_FA2_CMP=1 NSA_USE_FA2_WIN=0
```

A/B runs
1) Baseline (mixed off)
```bash
unset NSA_P_CMP_MIXED
# Correctness
PYTHONPATH=. uv run -q pytest -q nsa/tests/test_selection_v2_equiv.py
PYTHONPATH=. uv run -q pytest -q nsa/tests/test_equiv_small.py nsa/tests/test_group_consistency.py nsa/tests/test_masks.py nsa/tests/test_block_math.py
# Benchmarks
PYTHONPATH=. uv run python bench/bench_decode.py --S_list 512,1024,2048
CONFIG=configs/base.yaml PYTHONPATH=. uv run -q python -u scripts/train_showcase.py --dataset fineweb_edu --ddp 0 --steps 200
```
2) Mixed precision ON
```bash
export NSA_P_CMP_MIXED=1
# Repeat the same battery
PYTHONPATH=. uv run -q pytest -q nsa/tests/test_selection_v2_equiv.py
PYTHONPATH=. uv run -q pytest -q nsa/tests/test_equiv_small.py nsa/tests/test_group_consistency.py nsa/tests/test_masks.py nsa/tests/test_block_math.py
PYTHONPATH=. uv run python bench/bench_decode.py --S_list 512,1024,2048
CONFIG=configs/base.yaml PYTHONPATH=. uv run -q python -u scripts/train_showcase.py --dataset fineweb_edu --ddp 0 --steps 200
```

What to look for
- All tests green in both modes; no NaNs; selection v2 parity intact.
- Decode bench and 200‑step training tokens/sec improved or unchanged with `NSA_P_CMP_MIXED=1`.
- No behavior changes when the flag is OFF (default).

Acceptance
- No correctness/stability regressions.
- Non‑regressing (ideally improved) throughput at larger S with the flag enabled.

Notes
- This PR is independent of selection varlen PR. It complements varlen selection by cutting bandwidth earlier in the selection scoring pipeline.
