### PR TITLE
PR34 — Mixed Precision Selection Mapping (p_slc/p_grp)

### DIFF
--- a/Documentation/PRs/PR34 - Mixed Precision Selection Mapping.md
+++ b/Documentation/PRs/PR34 - Mixed Precision Selection Mapping.md
@@ -1,0 +1,41 @@
+Title: PR34 — Mixed Precision Selection Mapping (p_slc/p_grp)
+
+Summary
+- Adds opt-in mixed precision to the selection mapping pipeline to reduce bandwidth and math cost while preserving stable selection ordering.
+- Two flags:
+  - `NSA_P_SLC_MIXED=1`: compute `map_pcmp_to_pslc_batched` under CUDA autocast(bfloat16), then upcast the result to the original dtype.
+  - `NSA_P_GRP_FP32=1`: cast grouped scores `p_grp` to float32 before top‑k selection to stabilize tie‑breaks.
+
+Changes
+- nsa/core/selection_scorer.py
+  - `map_pcmp_to_pslc_batched`: optional autocast(bfloat16) on CUDA guarded by `NSA_P_SLC_MIXED`; results are upcast back to the original dtype for downstream code.
+  - Safe fallback to precise path if autocast isn’t available or raises.
+- nsa/core/nsa_attention.py
+  - In batched and sequential prefill paths, optionally cast `p_grp_all` to float32 when `NSA_P_GRP_FP32=1` before calling `select_topn_ranges_batched`.
+
+Rationale
+- `p_cmp_all` (B,S,G,h,S_cmp) → `p_slc_all` (B,S,G,h,S_sel) mapping is bandwidth-heavy. On A100/H100, bfloat16 autocast meaningfully reduces memory traffic while maintaining adequate precision for the weighted scatter-add.
+- Performing the top‑k in float32 preserves ranking stability and tie‑break behavior; this is especially helpful when upstream steps use mixed precision.
+
+Correctness
+- By upcasting `p_slc` back to the original dtype and performing top‑k in float32 (when enabled), we preserve existing selection behavior and tie‑break ordering.
+- The feature is opt-in and defaults OFF; existing tests and numerics remain unchanged by default.
+
+Test Plan
+1) Parity (defaults OFF)
+   - `pytest -q nsa/tests/test_selection_v2_equiv.py`
+   - `pytest -q nsa/tests/test_selection_tiebreak.py`
+2) CUDA opt-in checks (A100/H100)
+   - `NSA_P_SLC_MIXED=1 NSA_P_GRP_FP32=1 pytest -q nsa/tests/test_selection_v2_equiv.py`
+   - Verify `test_selection_tiebreak` still passes and tie-break warnings are absent.
+3) Microbench (optional)
+   - Prefill bench: `PYTHONPATH=. uv run -q python bench/bench_prefill.py --config configs/base.yaml`
+   - Env: `NSA_USE_SEL_PACK=1 NSA_P_SLC_MIXED=1 NSA_P_GRP_FP32=1`
+
+Performance Expectations
+- Moderate improvement on larger shapes due to reduced memory traffic in `map_pcmp_to_pslc_batched`.
+- Tie‑break stability maintained by float32 top‑k.
+
+Rollout & Safety
+- Both flags default OFF. Enable selectively in performance runs (`NSA_P_SLC_MIXED=1` and `NSA_P_GRP_FP32=1`).
+- No changes to behavior when flags are unset.

--- a/nsa/core/nsa_attention.py
+++ b/nsa/core/nsa_attention.py
@@ -943,6 +943,12 @@ class NSAAttention(nn.Module):
                 pass
         p_slc_all = map_pcmp_to_pslc_batched(p_cmp_all, kv.meta)  # [B,S,G,h,S_sel]
 
+        # Optional: cast group scores to fp32 before top‑k to stabilize tie‑breaks under mixed modes
+        if os.getenv("NSA_P_GRP_FP32", "0").lower() in ("1", "true", "yes", "on"):
+            p_grp_all = p_slc_all.sum(dim=3).to(torch.float32)
+        else:
+            p_grp_all = p_slc_all.sum(dim=3)  # [B,S,G,S_sel]
+
         # M8: Optional Eq.9 verification in batched prefill
         if self._env_cache.get("verify_eq9", False):
             is_equiv, details = verify_mapping_equivalence(p_cmp_all, kv.meta)
@@ -952,7 +958,6 @@ class NSAAttention(nn.Module):
                     msg="Eq.9 mapping verification failed in batched prefill",
                     **details,
                 )
-        p_grp_all = p_slc_all.sum(dim=3)  # [B,S,G,S_sel]
         log(
             "prefill.scores",
             B=B,
@@ -1375,7 +1380,10 @@ class NSAAttention(nn.Module):
         scale = 1.0 / (self.d_k**0.5)
         p_cmp_all = compute_pcmp_all(Q, kv.K_cmp, scale)  # [B,S,G,h,S_cmp]
         p_slc_all = map_pcmp_to_pslc_batched(p_cmp_all, kv.meta)  # [B,S,G,h,S_sel]
-        p_grp_all = p_slc_all.sum(dim=3)  # [B,S,G,S_sel]
+        if os.getenv("NSA_P_GRP_FP32", "0").lower() in ("1", "true", "yes", "on"):
+            p_grp_all = p_slc_all.sum(dim=3).to(torch.float32)
+        else:
+            p_grp_all = p_slc_all.sum(dim=3)  # [B,S,G,S_sel]
 
         outs = []
         sel_ranges_accum: List[torch.Tensor] = []

--- a/nsa/core/selection_scorer.py
+++ b/nsa/core/selection_scorer.py
@@ -96,24 +96,34 @@ def map_pcmp_to_pslc_batched(p_cmp_all: torch.Tensor, meta: BlockMeta) -> torch.
     S_sel = meta.sel_starts.numel()
     if S_cmp == 0:
         return torch.zeros((B, S, G, h, S_sel), device=device, dtype=p_cmp_all.dtype)
-    # COO sparse matmul: for each nnz (r,c,w), add p_cmp[..., r]*w to p_slc[..., c]
-    rows, cols = meta.M_csl_coo_indices.to(device)
-    w = meta.M_csl_coo_values.to(device=device, dtype=p_cmp_all.dtype)
-    # Filter mapping rows to those < current S_cmp to avoid out-of-bounds in early decode
-    valid_mask = rows < S_cmp
-    if valid_mask.dim() == 0:
-        valid_mask = valid_mask.unsqueeze(0)
-    rows = rows[valid_mask]
-    cols = cols[valid_mask]
-    w = w[valid_mask]
-    if rows.numel() == 0:
-        return torch.zeros((B, S, G, h, S_sel), device=device, dtype=p_cmp_all.dtype)
-    p_src = p_cmp_all[..., rows] * w  # [B,S,G,h,nnz]
-    p_slc = torch.zeros((B, S, G, h, S_sel), device=device, dtype=p_cmp_all.dtype)
-    # Ensure Long dtype for scatter_add indices
-    idx = cols.view(1, 1, 1, 1, -1).expand(B, S, G, h, -1).long()
-    p_slc = p_slc.scatter_add(-1, idx, p_src)
-    return p_slc
+    use_mixed = os.getenv("NSA_P_SLC_MIXED", "0").lower() in ("1", "true", "yes", "on")
+    # Baseline precise path (also used as fallback if autocast fails)
+    def _compute(p_src_all: torch.Tensor, dtype_out: torch.dtype) -> torch.Tensor:
+        rows, cols = meta.M_csl_coo_indices.to(device)
+        w_vals = meta.M_csl_coo_values.to(device=device, dtype=p_src_all.dtype)
+        valid_mask = rows < S_cmp
+        if valid_mask.dim() == 0:
+            valid_mask = valid_mask.unsqueeze(0)
+        rows_v = rows[valid_mask]
+        cols_v = cols[valid_mask]
+        w_v = w_vals[valid_mask]
+        if rows_v.numel() == 0:
+            return torch.zeros((B, S, G, h, S_sel), device=device, dtype=dtype_out)
+        p_src = p_src_all[..., rows_v] * w_v  # [B,S,G,h,nnz]
+        p_slc_local = torch.zeros((B, S, G, h, S_sel), device=device, dtype=p_src_all.dtype)
+        idx = cols_v.view(1, 1, 1, 1, -1).expand(B, S, G, h, -1).long()
+        p_slc_local = p_slc_local.scatter_add(-1, idx, p_src)
+        return p_slc_local.to(dtype_out)
+
+    if use_mixed and device.type == "cuda":
+        orig_dtype = p_cmp_all.dtype
+        try:
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                return _compute(p_cmp_all, orig_dtype)
+        except Exception:
+            return _compute(p_cmp_all, orig_dtype)
+    else:
+        return _compute(p_cmp_all, p_cmp_all.dtype)
 
 
 def group_reduce_pslc(p_slc: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Title: PR34 — Mixed Precision Selection Mapping (p_slc/p_grp)

Summary
- Adds opt-in mixed precision to the selection mapping pipeline to reduce bandwidth and math cost while preserving stable selection ordering.
- Two flags:
  - `NSA_P_SLC_MIXED=1`: compute `map_pcmp_to_pslc_batched` under CUDA autocast(bfloat16), then upcast the result to the original dtype.
  - `NSA_P_GRP_FP32=1`: cast grouped scores `p_grp` to float32 before top‑k selection to stabilize tie‑breaks.

Changes
- nsa/core/selection_scorer.py
  - `map_pcmp_to_pslc_batched`: optional autocast(bfloat16) on CUDA guarded by `NSA_P_SLC_MIXED`; results are upcast back to the original dtype for downstream code.
  - Safe fallback to precise path if autocast isn’t available or raises.
- nsa/core/nsa_attention.py
  - In batched and sequential prefill paths, optionally cast `p_grp_all` to float32 when `NSA_P_GRP_FP32=1` before calling `select_topn_ranges_batched`.

Rationale
- `p_cmp_all` (B,S,G,h,S_cmp) → `p_slc_all` (B,S,G,h,S_sel) mapping is bandwidth-heavy. On A100/H100, bfloat16 autocast meaningfully reduces memory traffic while maintaining adequate precision for the weighted scatter-add.
- Performing the top‑k in float32 preserves ranking stability and tie‑break behavior; this is especially helpful when upstream steps use mixed precision.

Correctness
- By upcasting `p_slc` back to the original dtype and performing top‑k in float32 (when enabled), we preserve existing selection behavior and tie‑break ordering.
- The feature is opt-in and defaults OFF; existing tests and numerics remain unchanged by default.

Test Plan
1) Parity (defaults OFF)
   - `pytest -q nsa/tests/test_selection_v2_equiv.py`
   - `pytest -q nsa/tests/test_selection_tiebreak.py`
2) CUDA opt-in checks (A100/H100)
   - `NSA_P_SLC_MIXED=1 NSA_P_GRP_FP32=1 pytest -q nsa/tests/test_selection_v2_equiv.py`
   - Verify `test_selection_tiebreak` still passes and tie-break warnings are absent.
3) Microbench (optional)
   - Prefill bench: `PYTHONPATH=. uv run -q python bench/bench_prefill.py --config configs/base.yaml`
   - Env: `NSA_USE_SEL_PACK=1 NSA_P_SLC_MIXED=1 NSA_P_GRP_FP32=1`

Performance Expectations
- Moderate improvement on larger shapes due to reduced memory traffic in `map_pcmp_to_pslc_batched`.
- Tie‑break stability maintained by float32 top‑k.

Rollout & Safety
- Both flags default OFF. Enable selectively in performance runs (`NSA_P_SLC_MIXED=1` and `NSA_P_GRP_FP32=1`).
- No changes to behavior when flags are unset.
