### PR TITLE
chore(a100): disable FA-2 by default; runbook updates for selection varlen and loader warmup

### DIFF
--- a/Documentation/Operations/production-runbook.md
+++ b/Documentation/Operations/production-runbook.md
@@ -582,3 +582,14 @@ rsync -av training_backup_*.tar.gz user@backup-server:/backups/nsa/
 ```
 
 This runbook provides comprehensive operational procedures for production NSA training systems. Keep it updated as new features and optimizations are added to the system.
+### FA‑2 and Selection Defaults (A100)
+- Disable FA‑2 by default on A100. SDPA outperforms FA‑2 for our shapes.
+  - Set `NSA_USE_FA2=0`
+  - In `configs/profiles/a100.yaml`: `runtime.fa2_min_len_win: 999999`, `runtime.fa2_min_len_cmp: 999999`.
+- Keep selection varlen disabled by default: `NSA_USE_SEL_VARLEN=0`.
+- If enabling selection varlen for experiments, rely on masked SDPA fallback (PR40) for correctness and performance.
+
+### Data Loader Settings
+- Enable prefetch and tune queue depth to reduce fetch p95 (`NSA_FWE_PREFETCH=1`, `NSA_FWE_Q=8..16`).
+- Optional warmup (PR36): `NSA_FWE_WARMUP_BATCHES=32..64`, `NSA_FWE_WARMUP_TIMEOUT=60` to reduce first‑step latency.
+- Optional bootstrap: pre‑stage ~5GB JSONL locally (see `scripts/automation/fwe_bootstrap.py`) for strict SLA starts.

--- a/configs/profiles/a100.yaml
+++ b/configs/profiles/a100.yaml
@@ -4,6 +4,6 @@ runtime:
   # Set after running selection benches with margin ≥ 1.2×
   sel_triton_min_L: 2048
   # Optional FA‑2 gates (tune via FA‑2 benches)
-  fa2_min_len_win: 256
-  fa2_min_len_cmp: 128
-
+  # Disable FA‑2 by default on A100 for our workload: SDPA is faster
+  fa2_min_len_win: 999999
+  fa2_min_len_cmp: 999999


### PR DESCRIPTION
- Set runtime.fa2_min_len_{win,cmp}=999999 for A100 profile (SDPA faster for our shapes)
- Runbook: document FA-2 off, selection varlen off by default; add loader warmup (PR36) and optional bootstrap script reference.
- No code changes; safe config/docs only.