### PR TITLE
FA-2: Bulletproofing (contracts, repro, tests, bench CSV) + Startup Audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,8 @@ jobs:
             nsa/tests/test_equiv_small.py \
             nsa/tests/test_equiv_full_coverage.py \
             nsa/tests/test_decode_reads_trend.py \
-            nsa/tests/test_phi_mlp_equiv.py
+            nsa/tests/test_phi_mlp_equiv.py \
+            | tee test-output.txt
 
       - name: Upload batched smoke log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           python -m pip install -U uv
           uv venv -p 3.11 .venv
           uv pip sync requirements-cpu.txt
+          uv pip install -e .
 
       - name: Environment diagnostics
         run: |
@@ -78,6 +79,7 @@ jobs:
           python -m pip install -U uv
           uv venv -p 3.11 .venv
           uv pip sync requirements-cpu.txt
+          uv pip install -e .
 
       - name: Run batched prefill smoke (CPU)
         env:

--- a/Documentation/Architecture/FA2-Integration-Guide.md
+++ b/Documentation/Architecture/FA2-Integration-Guide.md
@@ -1,0 +1,42 @@
+FA‑2 Integration Guide (NSA)
+
+What’s routed to FA‑2
+- Sliding window (win) decode: dense FA‑2 (`flash_attn_func`) when head_dim, dtype, and contiguity pass contracts; fallback to SDPA masked.
+- Compressed (cmp) decode: dense FA‑2 for per‑row batches; fallback to masked SDPA.
+- Selection: remains SDPA (packed/masked) for now; future varlen FA‑2 optional.
+
+Preconditions (runtime enforced)
+- Device: CUDA on SM80/89/90 GPUs.
+- Dtype: fp16 or bf16; fp32 falls back.
+- Head dim: multiple of 8; ≤128 on SM8x by default (guarded), ≤256 on SM9x.
+- Contiguity: q/k/v or qkv must be contiguous along packed dims.
+- Varlen: `cu_seqlens_*` must be int32, monotonic, `(B+1)`, `cu[0]=0`, `cu[-1]=nnz`.
+
+Fallback rules
+- Contracts fail → SDPA path with detailed log when `NSA_DEBUG_TIMING=1`.
+- Kernel import fails or raises → SDPA path (dense or masked) with log.
+
+Flags
+- `NSA_USE_FA2` (master switch), `NSA_USE_FA2_WIN`, `NSA_USE_FA2_CMP` (per‑branch).
+- `NSA_FA2_MIN_LEN_WIN`, `NSA_FA2_MIN_LEN_CMP` (min lengths to choose FA‑2).
+- `NSA_FA2_PREF_FP16` (prefer fp16 casts), `NSA_FA2_ALLOW_FP32` (rarely true).
+- `NSA_FA2_ALLOW_D_GT_128` (permit D>128 on SM8x with caution).
+- `NSA_FA2_AUDIT` (optional startup probe), `NSA_FA2_HARD_FAIL` (raise if eligible but blocked).
+
+Thresholds (starting points; tune via benches)
+- A100 (SM80):
+  - D≤128: win min Tk ≈192; cmp min Lc ≈64
+  - D=192: win ≈256; cmp ≈96
+  - D=256: win ≈320; cmp ≈128
+- H100 (SM90):
+  - D≤128: win ≈128; cmp ≈48
+  - D=192: win ≈160; cmp ≈64
+  - D=256: win ≈192; cmp ≈96
+
+Startup audit (optional)
+- Log device, SM, torch/flash‑attn versions; probe a tiny forward and record pass/fail and fallback reason.
+
+First responder checklist
+- Illegal memory access: validate `cu_seqlens_*` and contiguity; run `scripts/repro_fa2_crash.py` to reproduce.
+- Immediate FPE/NaNs: check dtype (fp32 drift) and strides; enforce `.to(fp16/bf16).contiguous()`.
+- “not implemented for head_dim”: verify `%8==0` and SM‑specific upper limits.

--- a/Documentation/Guides/FA2-Input-Contracts.md
+++ b/Documentation/Guides/FA2-Input-Contracts.md
@@ -1,0 +1,38 @@
+FA‑2 Input Contracts (NSA)
+
+Scope: FA‑2 fast paths used by NSA for compressed and sliding window decode (dense + varlen/kvpacked). Selection remains SDPA for now.
+
+Device / SW
+- GPUs: Ampere (SM80), Ada (SM89), Hopper (SM90).
+- Torch ≥ 2.4 (CUDA ≥ 12.1). flash-attn ≥ 2.5.5 recommended.
+- Kernel entry points: `flash_attn_func`, `flash_attn_qkvpacked_func`, and varlen siblings.
+
+Dtypes
+- Allowed: fp16, bf16. Disallowed: fp32 (force SDPA fallback).
+- Numerics: prefer fp16 for throughput unless model requires bf16.
+
+Head dimension
+- `head_dim % 8 == 0` (required).
+- SM80/SM89: allow up to 128 by default; permit 192/256 only with `NSA_FA2_ALLOW_D_GT_128=1`.
+- SM90: allow up to 256 by default.
+
+Contiguity / strides
+- Dense/QKV‑packed: inputs must be contiguous in the last 2 dims `(nheads, head_dim)` and the QKV packing dimension.
+- Varlen packed views must be contiguous slices; no strided/narrowed non‑unit strides along the packed dim.
+
+Varlen (`flash_attn_varlen_*`)
+- `qkv_unpadded`: shape `(nnz, 3, nheads, head_dim)` or `(nnz, nheads, head_dim)` depending on function.
+- `cu_seqlens`: `int32`, shape `(B+1,)`, monotonic non‑decreasing, `cu[0]=0`, `cu[-1]=nnz`.
+- For `kvpacked`, `cu_seqlens_k` may differ from `cu_seqlens_q` (prefill vs decode).
+
+Causal semantics & windows
+- NSA decode often slices K/V for strict causality; passing `causal=False` is valid iff K/V are sliced to `≤ t`.
+- For dense full‑length inputs (no slicing), set `causal=True` to avoid off‑by‑one on the last row.
+- Sliding window (`window_size=(L,R)`): pass inclusive `[i-L, i+R]`. With NSA’s win branch masking to `≤ t`, keep `causal=True` unless you pre‑slice K.
+
+Cheap runtime asserts to add
+- dtype check: {fp16,bf16}; else hard fallback.
+- head_dim: `%8==0` and `≤ 128 (SM8x)` or `≤ 256 (SM9x)` by default.
+- contiguity: `.is_contiguous()` on q/k/v or qkv along the packed dims.
+- varlen: `cu.dtype==torch.int32`; `cu.numel()==B+1`; `cu[0]==0`; `torch.all(cu[1:]>=cu[:-1])`.
+- decode safety: when passing `causal=False`, assert that the K slice ends at t.

--- a/Documentation/Guides/FA2-Input-Contracts.md
+++ b/Documentation/Guides/FA2-Input-Contracts.md
@@ -36,3 +36,4 @@ Cheap runtime asserts to add
 - contiguity: `.is_contiguous()` on q/k/v or qkv along the packed dims.
 - varlen: `cu.dtype==torch.int32`; `cu.numel()==B+1`; `cu[0]==0`; `torch.all(cu[1:]>=cu[:-1])`.
 - decode safety: when passing `causal=False`, assert that the K slice ends at t.
+- batch size: if effective batch `B > 1024`, require `NSA_FA2_ALLOW_LARGE_BATCH=1` or fallback.

--- a/Documentation/Guides/Troubleshooting-FA2.md
+++ b/Documentation/Guides/Troubleshooting-FA2.md
@@ -1,0 +1,25 @@
+Troubleshooting FA‑2 (NSA)
+
+Symptom → probable cause → fix
+
+- Illegal memory access
+  - Cause: malformed `cu_seqlens_*` (dtype/monotonic/size) or non‑contiguous packed buffers.
+  - Fix: enforce int32 `(B+1)`, `cu[0]=0`, `cu[-1]=nnz`, monotonic; ensure `.contiguous()`; repro via `scripts/repro_fa2_crash.py`.
+
+- Immediate FPE on H100
+  - Cause: dtype drift to fp32 or non‑contiguous views.
+  - Fix: cast to fp16/bf16 and `.contiguous()` before FA‑2 calls.
+
+- NaNs after FA‑2
+  - Cause: tiny windows + extreme logits; numerical instabilities.
+  - Fix: route to SDPA for very small lengths (e.g., T<16) and record inputs.
+
+- “not implemented for head_dim …”
+  - Cause: head_dim not multiple of 8 or exceeds SM limits.
+  - Fix: gate by `%8==0`; SM8x default ≤128 (optionally ≤256 behind `NSA_FA2_ALLOW_D>128`); SM9x ≤256.
+
+How to capture diagnostics
+- Export: `NSA_DEBUG_TIMING=1 NSA_SDPA_AUDIT=1`.
+- Run repro: `PYTHONPATH=. uv run -q python scripts/repro_fa2_crash.py`.
+- Artifacts: see `artifacts/2025-09-04/fa2_harden/` (JSON env + results, CSV from benches).
+

--- a/nsa/attn/__init__.py
+++ b/nsa/attn/__init__.py
@@ -1,0 +1,2 @@
+"""Attention helpers and FA-2 input contracts."""
+

--- a/nsa/attn/fa2_contracts.py
+++ b/nsa/attn/fa2_contracts.py
@@ -1,0 +1,76 @@
+import os
+import torch
+
+
+def _sm() -> int:
+    if not torch.cuda.is_available():
+        return 0
+    try:
+        c = torch.cuda.get_device_capability()
+        return 10 * c[0] + c[1]
+    except Exception:
+        return 0
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    v = os.getenv(name, "1" if default else "0").lower()
+    return v in ("1", "true", "yes", "on")
+
+
+def fa2_supported_verbose(
+    q: torch.Tensor | None = None,
+    k: torch.Tensor | None = None,
+    v: torch.Tensor | None = None,
+    qkv: torch.Tensor | None = None,
+    head_dim: int | None = None,
+    is_varlen: bool = False,
+):
+    sm = _sm()
+    ten = qkv if qkv is not None else (q if q is not None else (k if k is not None else v))
+    hd = head_dim if head_dim is not None else (ten.shape[-1] if ten is not None else None)  # type: ignore[index]
+    dtype_ok = ten is not None and ten.dtype in (torch.float16, torch.bfloat16)
+    contig_ok = (
+        (qkv is not None and qkv.is_contiguous())
+        or (
+            q is not None
+            and k is not None
+            and v is not None
+            and q.is_contiguous()
+            and k.is_contiguous()
+            and v.is_contiguous()
+        )
+    )
+    allow_d_gt_128 = _env_bool("NSA_FA2_ALLOW_D_GT_128", False)
+    hd_ok = (
+        hd is not None
+        and (hd % 8 == 0)
+        and (
+            (sm >= 90 and hd <= 256)
+            or (sm < 90 and (hd <= 128 or (allow_d_gt_128 and hd <= 256)))
+        )
+    )
+    reasons: list[str] = []
+    if not dtype_ok:
+        reasons.append("dtype must be fp16/bf16")
+    if not contig_ok:
+        reasons.append("non-contiguous tensor(s)")
+    if not hd_ok:
+        reasons.append(
+            f"head_dim={hd} invalid for SM{sm}; need %8==0 and ≤{256 if sm>=90 else (128 if not allow_d_gt_128 else 256)}"
+        )
+    return (dtype_ok and contig_ok and hd_ok), {"sm": sm, "hd": hd, "reasons": reasons}
+
+
+def check_cu_seqlens(cu: torch.Tensor, nnz: int, B: int) -> bool:
+    if cu.dtype != torch.int32:
+        return False
+    if cu.numel() != B + 1:
+        return False
+    if int(cu[0].item()) != 0:
+        return False
+    if int(cu[-1].item()) != nnz:
+        return False
+    try:
+        return bool(torch.all(cu[1:] >= cu[:-1]))
+    except Exception:
+        return False

--- a/nsa/core/nsa_attention.py
+++ b/nsa/core/nsa_attention.py
@@ -26,7 +26,7 @@ from nsa.core.selection_scorer import (
     select_topn_ranges_batched,
     verify_mapping_equivalence,
 )
-from nsa.kernels.flash_wrappers import attention_bgh, audit_fa2_support
+from nsa.kernels.flash_wrappers import attention_bgh, audit_fa2_support, log_fa2_support_matrix
 
 
 class GateMLP(nn.Module):
@@ -288,11 +288,12 @@ class NSAAttention(nn.Module):
                 self.phi_v_conv.weight.fill_(1.0 / float(self.l))
         else:
             self.phi_k_conv = None
-            self.phi_v_conv = None
+        self.phi_v_conv = None
         # Optional FA-2 audit on init (best-effort; logs only)
         try:
             if os.getenv("NSA_FA2_AUDIT", "0").lower() in ("1", "true", "yes", "on"):
                 audit_fa2_support(self.d_k, heads=self.h_per_group)
+                log_fa2_support_matrix()
         except Exception:
             pass
 

--- a/nsa/core/nsa_attention.py
+++ b/nsa/core/nsa_attention.py
@@ -26,7 +26,7 @@ from nsa.core.selection_scorer import (
     select_topn_ranges_batched,
     verify_mapping_equivalence,
 )
-from nsa.kernels.flash_wrappers import attention_bgh
+from nsa.kernels.flash_wrappers import attention_bgh, audit_fa2_support
 
 
 class GateMLP(nn.Module):
@@ -289,6 +289,12 @@ class NSAAttention(nn.Module):
         else:
             self.phi_k_conv = None
             self.phi_v_conv = None
+        # Optional FA-2 audit on init (best-effort; logs only)
+        try:
+            if os.getenv("NSA_FA2_AUDIT", "0").lower() in ("1", "true", "yes", "on"):
+                audit_fa2_support(self.d_k, heads=self.h_per_group)
+        except Exception:
+            pass
 
     def _cache_env_vars(self) -> None:
         """Cache environment variables to avoid repeated parsing in hot path."""

--- a/nsa/tests/test_fa2_edge_shapes_gpu.py
+++ b/nsa/tests/test_fa2_edge_shapes_gpu.py
@@ -1,0 +1,26 @@
+import os
+import torch
+import pytest
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for FA-2 edge tests")
+
+
+RUN_FA2 = os.getenv("NSA_TEST_FA2", "0").lower() in ("1", "true", "yes", "on")
+
+
+@pytest.mark.skipif(not RUN_FA2, reason="FA-2 parity tests are opt-in; set NSA_TEST_FA2=1")
+def test_tiny_lengths_and_t1_decode():
+    # Ensure T=1 decode behaves and no NaNs for tiny windows
+    from nsa.core.attention_kernels import sliding_window_attention_fa2
+
+    B, S, G, h, D = 1, 8, 2, 2, 64
+    device = torch.device("cuda")
+    Q = torch.randn(B, S, G, h, D, device=device, dtype=torch.float16)
+    K = torch.randn(B, G, S, D, device=device, dtype=torch.float16)
+    V = torch.randn(B, G, S, D, device=device, dtype=torch.float16)
+    # Window of 1 → strictly causal single-key per row
+    out = sliding_window_attention_fa2(Q, K, V, w=1)
+    assert torch.isfinite(out).all()
+    # First row attends only to index 0
+    assert out.shape == (B, S, G, h, D)
+

--- a/nsa/tests/test_fa2_parity_gpu.py
+++ b/nsa/tests/test_fa2_parity_gpu.py
@@ -1,0 +1,44 @@
+import os
+import torch
+import pytest
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for FA-2 parity tests")
+
+
+RUN_FA2 = os.getenv("NSA_TEST_FA2", "0").lower() in ("1", "true", "yes", "on")
+
+
+@pytest.mark.skipif(not RUN_FA2, reason="FA-2 parity tests are opt-in; set NSA_TEST_FA2=1")
+def test_fa2_env_ready():
+    try:
+        import flash_attn  # noqa: F401
+    except Exception as e:
+        pytest.skip(f"flash-attn not importable: {e}")
+
+
+def _rand(B, T, H, D, dt):
+    return torch.randn(B, T, H, D, device="cuda", dtype=dt)
+
+
+@pytest.mark.skipif(not RUN_FA2, reason="FA-2 parity tests are opt-in; set NSA_TEST_FA2=1")
+@pytest.mark.parametrize("D", [64, 96, 128, 192, 256])
+@pytest.mark.parametrize("T", [1, 8, 16, 32, 96, 128])
+@pytest.mark.parametrize("dt", [torch.float16, torch.bfloat16])
+def test_dense_vs_sdpa(D, T, dt):
+    from nsa.attn.fa2_contracts import fa2_supported_verbose
+    from flash_attn import flash_attn_func
+
+    q = _rand(1, T, 8, D, dt)
+    k = _rand(1, T, 8, D, dt)
+    v = _rand(1, T, 8, D, dt)
+    out_sdpa = torch.nn.functional.scaled_dot_product_attention(
+        q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), is_causal=True, dropout_p=0.0
+    )
+    ok, _ = fa2_supported_verbose(q=q, k=k, v=v, head_dim=D, is_varlen=False)
+    if not ok:
+        pytest.skip("FA-2 not supported for this config by contracts")
+    out_fa = flash_attn_func(q, k, v, dropout_p=0.0, causal=True)
+    atol = 5e-3 if dt == torch.float16 else 7e-3
+    rtol = 5e-3 if dt == torch.float16 else 7e-3
+    torch.testing.assert_close(out_fa, out_sdpa, atol=atol, rtol=rtol)
+

--- a/nsa/tests/test_fa2_varlen_parity_gpu.py
+++ b/nsa/tests/test_fa2_varlen_parity_gpu.py
@@ -1,0 +1,37 @@
+import os
+import torch
+import pytest
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for FA-2 varlen tests")
+
+
+RUN_FA2 = os.getenv("NSA_TEST_FA2", "0").lower() in ("1", "true", "yes", "on")
+
+
+@pytest.mark.skipif(not RUN_FA2, reason="FA-2 parity tests are opt-in; set NSA_TEST_FA2=1")
+def test_selection_varlen_v2_matches_masked_small():
+    # Small case with simple ranges; ensures v2 varlen path matches masked reference
+    from nsa.core.attention_kernels import (
+        selection_attention_varlen_all_v2,
+        grouped_selection_attention_masked,
+    )
+
+    B, S, G, h, D = 1, 4, 2, 2, 64
+    device = torch.device("cuda")
+    Q = torch.randn(B, S, G, h, D, device=device, dtype=torch.float16)
+    K = torch.randn(B, G, S, D, device=device, dtype=torch.float16)
+    V = torch.randn(B, G, S, D, device=device, dtype=torch.float16)
+    # Ranges: allow [0..t] per row (causal)
+    n = 2
+    ranges = torch.zeros(B, S, G, n, 2, device=device, dtype=torch.int32)
+    for t in range(S):
+        ranges[:, t, :, 0, 0] = 0
+        ranges[:, t, :, 0, 1] = t + 1
+        ranges[:, t, :, 1, 0] = t + 1
+        ranges[:, t, :, 1, 1] = t + 1  # empty second segment beyond t
+
+    out_masked = grouped_selection_attention_masked(Q, K, V, ranges)
+    out_v2 = selection_attention_varlen_all_v2(Q, K, V, ranges)
+
+    torch.testing.assert_close(out_v2, out_masked, atol=5e-3, rtol=5e-3)
+

--- a/nsa/utils/varlen_validate.py
+++ b/nsa/utils/varlen_validate.py
@@ -1,0 +1,23 @@
+import torch
+from nsa.attn.fa2_contracts import check_cu_seqlens
+
+
+def validate_varlen_packing(
+    qkv_unpad: torch.Tensor,
+    cu: torch.Tensor,
+    B: int,
+    max_seqlen: int,
+    expect_packed_dim: int = 3,
+) -> bool:
+    assert qkv_unpad.is_cuda, "varlen path is CUDA-only"
+    assert qkv_unpad.dtype in (torch.float16, torch.bfloat16)
+    assert qkv_unpad.is_contiguous(), "qkv_unpad must be contiguous"
+    nnz = qkv_unpad.shape[0]
+    assert check_cu_seqlens(cu, nnz, B), "invalid cu_seqlens"
+    assert max_seqlen > 0 and max_seqlen <= nnz, "max_seqlen out of range"
+    if qkv_unpad.dim() == 4:
+        assert (
+            qkv_unpad.shape[1] == 3
+        ), "need qkv-packed (nnz,3,H,D) for qkvpacked kernels"
+    return True
+

--- a/scripts/repro_fa2_crash.py
+++ b/scripts/repro_fa2_crash.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Minimal, deterministic FA-2 crash repro + guard suggestions.
+Runs dense, varlen, and kvpacked kernels across known brittle preconditions.
+Saves a JSON+TXT bundle under artifacts/2025-09-04/fa2_harden/repro/.
+"""
+import os, json, time, platform, traceback
+import torch
+
+# Try latest FA-2 entry points (works across 2.x):
+try:
+    from flash_attn import (
+        flash_attn_func,
+        flash_attn_qkvpacked_func,
+        flash_attn_varlen_func,
+        flash_attn_varlen_qkvpacked_func,
+        flash_attn_varlen_kvpacked_func,
+    )  # type: ignore
+    FA_OK = True
+    import flash_attn as _fa  # type: ignore
+    FA_VERSION = getattr(_fa, "__version__", "unknown")
+except Exception as e:  # pragma: no cover - import probe
+    FA_OK = False
+    FA_VERSION = f"import-error: {e}"
+
+ARTDIR = "artifacts/2025-09-04/fa2_harden/repro"
+os.makedirs(ARTDIR, exist_ok=True)
+
+
+def env_summary():
+    dev = torch.cuda.current_device() if torch.cuda.is_available() else None
+    name = torch.cuda.get_device_name(dev) if dev is not None else "cpu"
+    cc = torch.cuda.get_device_capability(dev) if dev is not None else (0, 0)
+    sm = 10 * cc[0] + cc[1]
+    return {
+        "python": platform.python_version(),
+        "torch": torch.__version__,
+        "cuda_is_available": torch.cuda.is_available(),
+        "device_name": name,
+        "sm": sm,
+        "driver": torch.version.cuda,
+        "flash_attn": FA_VERSION,
+        "env": {k: v for k, v in os.environ.items() if k.startswith("NSA_") or k.startswith("CUDA_")},
+    }
+
+
+def log(msg):
+    print(f"[repro] {msg}")
+
+
+def run_case(name, fn):
+    rec = {"name": name, "ok": False, "error": None, "trace": None}
+    t0 = time.time()
+    try:
+        fn()
+        rec["ok"] = True
+    except Exception as e:  # pragma: no cover - interactive repro script
+        rec["error"] = repr(e)
+        rec["trace"] = traceback.format_exc()
+    rec["ms"] = (time.time() - t0) * 1000
+    log(f"{name}: {'OK' if rec['ok'] else 'FAIL'} ({rec['ms']:.1f} ms)")
+    return rec
+
+
+def make_qkv(B=2, T=128, H=8, D=128, dtype=torch.float16, contig=True):
+    qkv = torch.randn(B, T, 3, H, D, device="cuda", dtype=dtype, requires_grad=True)
+    if not contig:
+        # non-contiguous via transpose + narrow view (classic repro)
+        qkv = qkv.transpose(1, 3)[:, :T]
+    return qkv
+
+
+def case_dense_fp32_crash():
+    # fp32 is not supported by FA-2 CUDA kernels; expect failure or fallback
+    qkv = make_qkv(dtype=torch.float32)
+    flash_attn_qkvpacked_func(qkv, dropout_p=0.0, causal=True)  # type: ignore[name-defined]
+
+
+def case_noncontig_qkv():
+    qkv = make_qkv(dtype=torch.float16, contig=False)
+    flash_attn_qkvpacked_func(qkv, dropout_p=0.0, causal=True)  # type: ignore[name-defined]
+
+
+def _bad_cu_seqlens(nnz, B, dtype=torch.int64, monotonic=False):
+    # wrong dtype + non-monotonic to trigger illegal memory access in buggy wrappers
+    x = torch.zeros(B + 1, device="cuda", dtype=dtype)
+    if monotonic:
+        step = nnz // B
+        for i in range(1, B + 1):
+            x[i] = min(nnz, i * step)
+    else:
+        # make a violation
+        x[1:] = 1
+    return x
+
+
+def case_varlen_invalid_cu_seqlens():
+    B, T, H, D = 4, 64, 8, 64
+    qkv = make_qkv(B=B, T=T, H=H, D=D, dtype=torch.float16)
+    qkv = qkv.reshape(B * T, 3, H, D)  # (nnz, 3, H, D) for varlen qkvpacked
+    cu = _bad_cu_seqlens(nnz=B * T, B=B, dtype=torch.int64, monotonic=False)  # int64 + non-monotonic
+    flash_attn_varlen_qkvpacked_func(qkv, cu, T, 0.0, causal=True)  # type: ignore[name-defined]
+
+
+def case_head_dim_sm_limit():
+    # Try head_dim=256 on SM8x to demonstrate guard failure (or expect slow/fallback).
+    # This should be gated by your fa2_supported_verbose, but we call directly here.
+    H, D = 8, 256
+    B, T = 1, 128
+    qkv = make_qkv(B=B, T=T, H=H, D=D, dtype=torch.bfloat16)
+    flash_attn_qkvpacked_func(qkv, 0.0, causal=True)  # type: ignore[name-defined]
+
+
+def main():
+    recs = []
+    summ = env_summary()
+    log(f"ENV: {json.dumps(summ, indent=2)}")
+    if not torch.cuda.is_available():
+        log("CUDA not available; nothing to repro.")
+    else:
+        torch.cuda.synchronize()
+        for name, fn in [
+            ("dense_fp32", case_dense_fp32_crash),
+            ("noncontig_qkv", case_noncontig_qkv),
+            ("varlen_invalid_cu_seqlens", case_varlen_invalid_cu_seqlens),
+            ("head_dim_sm_limit", case_head_dim_sm_limit),
+        ]:
+            recs.append(run_case(name, fn))
+            torch.cuda.synchronize()
+    out = {"env": summ, "results": recs}
+    with open(os.path.join(ARTDIR, "repro_results.json"), "w") as f:
+        json.dump(out, f, indent=2)
+    with open(os.path.join(ARTDIR, "repro_readme.txt"), "w") as f:
+        f.write("Repro logs for FA-2 crashes / precondition violations.\n")
+    log(f"Wrote artifacts to {ARTDIR}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Summary
- Enforce FA‑2 input contracts at call sites (dtype, contiguity, SM+head_dim caps) with safe SDPA fallbacks and detailed logging.
- Add deterministic crash repro (scripts/repro_fa2_crash.py) for the 4 brittle classes (fp32, non‑contiguous, bad cu_seqlens, head_dim/SM limits).
- Add varlen cu_seqlens validator + selection varlen sanity helpers.
- Add GPU parity + edge-shape tests (opt‑in via NSA_TEST_FA2=1).
- Augment bench/bench_fa2.py with CSV sweep and environment snapshot.
- Add startup audit (NSA_FA2_AUDIT) to proactively verify FA‑2 availability on device.

Code changes
- nsa/kernels/flash_wrappers.py
  - Dense: cast to fp16/bf16 and make contiguous, then gate FA‑2 via contracts; else SDPA fallback.
  - Varlen: enforce contiguity, validate cu_seqlens (int32, monotonic, (B+1), 0→nnz), gate FA‑2; kvpacked fallback; else raise to outer fallback.
- nsa/attn/fa2_contracts.py (new)
  - fa2_supported_verbose: dtype∈{fp16,bf16}, contiguity, head_dim%8==0, SM caps (≤128 on SM8x by default; ≤256 on SM9x; SM8x override via NSA_FA2_ALLOW_D_GT_128=1).
  - check_cu_seqlens: strict varlen validator.
- nsa/utils/varlen_validate.py (new): reusable varlen packing validator.
- nsa/core/nsa_attention.py: optional startup audit call in __init__ when NSA_FA2_AUDIT=1.
- bench/bench_fa2.py: add CSV sweep mode (fa2_vs_sdpa.csv + bench_env.json under artifacts/2025-09-04/fa2_harden/).
- scripts/repro_fa2_crash.py (new): deterministic repro for crash classes.
- tests (opt-in GPU):
  - nsa/tests/test_fa2_parity_gpu.py
  - nsa/tests/test_fa2_varlen_parity_gpu.py
  - nsa/tests/test_fa2_edge_shapes_gpu.py

Docs
- Documentation/Guides/FA2-Input-Contracts.md (single-source inputs/guards)
- Documentation/Architecture/FA2-Integration-Guide.md (routing, thresholds, flags)
- Documentation/Guides/Troubleshooting-FA2.md (symptom→cause→fix)

New/updated flags
- NSA_FA2_ALLOW_D_GT_128 (default 0): permit D>128 on SM8x.
- NSA_FA2_AUDIT (default 0): log-only startup audit (tiny FA‑2 probe) in NSAAttention.__init__.
- Existing: NSA_USE_FA2[_WIN|_CMP], NSA_FA2_MIN_LEN_[WIN|CMP], NSA_FA2_PREF_FP16, NSA_FA2_ALLOW_FP32, NSA_DEBUG_TIMING, NSA_SDPA_AUDIT.

Reviewer checklist
- [ ] GPU: Run repro to confirm failures are contained (no hard crash)
  - PYTHONPATH=. uv run -q python scripts/repro_fa2_crash.py
  - Artifacts: artifacts/2025-09-04/fa2_harden/repro/
- [ ] GPU: Run parity tests (opt-in)
  - NSA_TEST_FA2=1 PYTHONPATH=. uv run -q pytest -k "fa2_parity_gpu or fa2_varlen_parity_gpu or fa2_edge_shapes_gpu"
- [ ] GPU: Run CSV sweep and inspect knees
  - PYTHONPATH=. NSA_USE_FA2=1 uv run python bench/bench_fa2.py --csv-sweep
  - Inspect artifacts/2025-09-04/fa2_harden/fa2_vs_sdpa.csv + bench_env.json and update fa2_thresholds.md.
- [ ] Verify logs under NSA_DEBUG_TIMING=1 show clear path/fallback reasons.

Notes
- Contracts mirror upstream FA‑2 constraints (fp16/bf16 only; ×8 head_dim; SM caps). Varlen cu_seqlens checks neutralize common illegal memory access causes.
- Startup audit is best-effort and logs only; never throws.
- Selection remains SDPA for now; varlen validator is ready if/when routing selection via FA‑2.

Once merged
- Tune and freeze min-length thresholds per device/head_dim.
- Consider enabling FA‑2 by default on H100/A100 with thresholds + audit gating.
